### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/README.adoc
+++ b/README.adoc
@@ -567,14 +567,12 @@ podman exec -it inventory /opt/ol/wlp/bin/productInfo featureInfo
 Your list of Liberty features should be similar to the following:
 ----
 jndi-1.0
-servlet-5.0
-cdi-3.0
-concurrent-2.0
-jsonb-2.0
-jsonp-2.0
-mpConfig-3.0
-restfulWS-3.0
-restfulWSClient-3.0
+cdi-4.0
+jsonb-3.0
+jsonp-2.1
+mpConfig-3.1
+restfulWS-3.1
+restfulWSClient-3.1
 ----
 
 // static guide instructions:

--- a/README.adoc
+++ b/README.adoc
@@ -253,13 +253,6 @@ include::finish/system/Containerfile-full[]
 
 Now that your microservices are packaged and your `Containerfile` files are written, you will build your container images by using the `podman build` command.
 
-Run the following command to download or update to the latest Open Liberty container image:
-
-[role='command']
-```
-podman pull icr.io/appcafe/open-liberty:kernel-slim-java11-openj9-ubi
-```
-
 Run the following commands to build container images for your application:
 
 [role='command']

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023 IBM Corporation and others.
+// Copyright (c) 2022, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -424,29 +424,29 @@ In this example, you will use an environment variable to externally configure th
 HTTP port number of the `inventory` service. 
 
 In the [hotspot file=0]`inventory/server.xml` file, 
-the [hotspot=httpPort file=0]`default.http.port` variable is declared and is used in the
+the [hotspot=httpPort file=0]`http.port` variable is declared and is used in the
 [hotspot=httpEndpoint file=0]`httpEndpoint` element to define the service
-endpoint. The default value of the [hotspot=httpPort file=0]`default.http.port`
+endpoint. The default value of the [hotspot=httpPort file=0]`http.port`
 variable is `9081`. However, this value is only used if no other value is specified. 
 You can replace this value in the container by using the -e flag for the podman run command. 
 
-Run the following commands to stop and remove the `inventory` container and rerun it with the `default.http.port` environment variable set:
+Run the following commands to stop and remove the `inventory` container and rerun it with the `http.port` environment variable set:
 
 [role='command']
 ```
 podman stop inventory
 podman rm inventory 
-podman run -d --name inventory -e default.http.port=9091 -p 9091:9091 inventory:1.0-SNAPSHOT
+podman run -d --name inventory -e http.port=9091 -p 9091:9091 inventory:1.0-SNAPSHOT
 ```
 
 The `-e` flag can be used to create and set the values of environment variables
-in a container. In this case, you are setting the `default.http.port` environment
+in a container. In this case, you are setting the `http.port` environment
 variable to `9091` for the `inventory` container. The `-p` flag then maps the local port
 to the new container port that was specified via the environment variable.
 
 Now, when the service is starting up, Open Liberty finds the
-`default.http.port` environment variable and uses it to set the value of the
-[hotspot=httpPort file=0]`default.http.port` variable to be used in the HTTP
+`http.port` environment variable and uses it to set the value of the
+[hotspot=httpPort file=0]`http.port` variable to be used in the HTTP
 endpoint.
 
 // static guide instructions:

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -20,8 +20,8 @@
         <system.ip>localhost</system.ip>
         <system.http.port>9080</system.http.port>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9081</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9444</liberty.var.default.https.port>
+        <liberty.var.http.port>9081</liberty.var.http.port>
+        <liberty.var.https.port>9444</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -43,25 +43,25 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <!-- For tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,24 +83,24 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <system.ip>${system.ip}</system.ip>
                         <system.http.port>${system.http.port}</system.http.port>
-                        <inventory.http.port>${liberty.var.default.http.port}</inventory.http.port>
+                        <inventory.http.port>${liberty.var.http.port}</inventory.http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -5,16 +5,16 @@
     <feature>jsonb-3.0</feature>
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
   </featureManager>
 
   <!-- tag::httpPort[] -->
-  <variable name="default.http.port" defaultValue="9081" />
+  <variable name="http.port" defaultValue="9081" />
   <!-- end::httpPort[] -->
-  <variable name="default.https.port" defaultValue="9444" />
+  <variable name="https.port" defaultValue="9444" />
 
   <!-- tag::httpEndpoint[] -->
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />
   <!-- end::httpEndpoint[] -->
 

--- a/finish/inventory/src/main/webapp/index.html
+++ b/finish/inventory/src/main/webapp/index.html
@@ -30,8 +30,8 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -17,8 +17,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -40,19 +40,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -69,22 +69,22 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <system.http.port>${liberty.var.default.http.port}</system.http.port>
+                        <system.http.port>${liberty.var.http.port}</system.http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -7,10 +7,10 @@
     <feature>cdi-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080" />
-  <variable name="default.https.port" defaultValue="9443" />
+  <variable name="http.port" defaultValue="9080" />
+  <variable name="https.port" defaultValue="9443" />
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />
 
   <webApplication location="system.war" contextRoot="/">

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -30,7 +30,7 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>

--- a/scripts/testAppFinish.sh
+++ b/scripts/testAppFinish.sh
@@ -58,7 +58,7 @@ fi
 
 podman stop inventory
 podman rm inventory
-podman run -d --name inventory -e default.http.port=9091 -p 9091:9091 inventory
+podman run -d --name inventory -e http.port=9091 -p 9091:9091 inventory
 
 sleep 30
 

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -20,8 +20,8 @@
         <system.ip>localhost</system.ip>
         <system.http.port>9080</system.http.port>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9081</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9444</liberty.var.default.https.port>
+        <liberty.var.http.port>9081</liberty.var.http.port>
+        <liberty.var.https.port>9444</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -43,25 +43,25 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <!-- For tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,24 +83,24 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <system.ip>${system.ip}</system.ip>
                         <system.http.port>${system.http.port}</system.http.port>
-                        <inventory.http.port>${liberty.var.default.http.port}</inventory.http.port>
+                        <inventory.http.port>${liberty.var.http.port}</inventory.http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -5,13 +5,13 @@
     <feature>jsonb-3.0</feature>
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9081" />
-  <variable name="default.https.port" defaultValue="9444" />
+  <variable name="http.port" defaultValue="9081" />
+  <variable name="https.port" defaultValue="9444" />
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />
 
   <webApplication location="inventory.war" contextRoot="/">

--- a/start/inventory/src/main/webapp/index.html
+++ b/start/inventory/src/main/webapp/index.html
@@ -30,8 +30,8 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -17,8 +17,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -40,19 +40,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -69,22 +69,22 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <system.http.port>${liberty.var.default.http.port}</system.http.port>
+                        <system.http.port>${liberty.var.http.port}</system.http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -7,10 +7,10 @@
     <feature>cdi-4.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080" />
-  <variable name="default.https.port" defaultValue="9443" />
+  <variable name="http.port" defaultValue="9080" />
+  <variable name="https.port" defaultValue="9443" />
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
       id="defaultHttpEndpoint" host="*" />
 
   <webApplication location="system.war" contextRoot="/">

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -30,7 +30,7 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

